### PR TITLE
fix: Fix Service TargetPort to Match Nginx Listening Port

### DIFF
--- a/argocd/example-app/service.yaml
+++ b/argocd/example-app/service.yaml
@@ -8,5 +8,5 @@ spec:
     app: argocd-example-app
   ports:
     - port: 3000
-      targetPort: 3000
+      targetPort: 80
       nodePort: 31000 # Optional: Kubernetes will choose a port if this is omitted


### PR DESCRIPTION
Fix Service TargetPort to Match Nginx Listening Port

Updated the target port in the Kubernetes service resource to align with the port Nginx that is configured to listen on (port 80). This resolves "connection refused" errors encountered when attempting to connect to the deployed application.
